### PR TITLE
feat(todo): ✨ TODOの親子関係管理機能を追加 (#1)

### DIFF
--- a/app/Http/Controllers/TodoRelationshipController.php
+++ b/app/Http/Controllers/TodoRelationshipController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use App\Models\Todo;
+use App\Models\TodoClosure;
+
+class TodoRelationshipController extends Controller
+{
+    // 親子関係をアタッチする
+    public function attach(Request $request, $todoId)
+    {
+        $validated = $request->validate([
+            'parent_id' => 'required|exists:todos,id', // 親が存在することを確認
+        ]);
+
+        $user = Auth::user();
+
+        // トランザクションで安全に関係を更新
+        return DB::transaction(function () use ($todoId, $validated, $user) {
+            // 子Todoを取得
+            $childTodo = $user->todos()->findOrFail($todoId);
+
+            // 親の閉包テーブルを取得
+            $parentRelations = TodoClosure::where('descendant_id', $validated['parent_id'])->get();
+
+            // 自分自身の閉包テーブルエントリを削除
+            TodoClosure::where('descendant_id', $childTodo->id)->delete();
+
+            // 新しい親子関係を作成
+            foreach ($parentRelations as $relation) {
+                TodoClosure::create([
+                    'ancestor_id' => $relation->ancestor_id,
+                    'descendant_id' => $childTodo->id,
+                    'depth' => $relation->depth + 1,
+                ]);
+            }
+
+            // 自分自身を閉包テーブルに追加
+            TodoClosure::create([
+                'ancestor_id' => $childTodo->id,
+                'descendant_id' => $childTodo->id,
+                'depth' => 0,
+            ]);
+
+            return response()->json(['message' => 'Parent attached successfully']);
+        });
+    }
+
+    // 親子関係をデタッチする
+    public function detach($todoId)
+    {
+        $user = Auth::user();
+
+        // トランザクションで安全に関係を解除
+        return DB::transaction(function () use ($todoId, $user) {
+            // 子Todoを取得
+            $childTodo = $user->todos()->findOrFail($todoId);
+
+            // 自分自身を含む閉包テーブルを削除
+            TodoClosure::where('descendant_id', $childTodo->id)->delete();
+
+            // 自分自身のみ閉包テーブルに追加
+            TodoClosure::create([
+                'ancestor_id' => $childTodo->id,
+                'descendant_id' => $childTodo->id,
+                'depth' => 0,
+            ]);
+
+            return response()->json(['message' => 'Parent detached successfully']);
+        });
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\ProjectTypeController;
 use App\Http\Controllers\ProjectController;
 use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\CategoryTodoController;
+use App\Http\Controllers\TodoRelationshipController;
 
 
 // Public routes
@@ -27,6 +28,10 @@ Route::middleware('auth:sanctum')->group(function () {
 
     // todos CRUD
     Route::apiResource('todos', TodoController::class);
+
+    // Attach and detach todos to todos
+    Route::post('/todos/{todoId}/attach-parent', [TodoRelationshipController::class, 'attach']);
+    Route::delete('/todos/{todoId}/detach-parent', [TodoRelationshipController::class, 'detach']);
 
     // Attach and detach categories to todos
     Route::post('/category-todo/{todoId}/attach', [CategoryTodoController::class, 'attach']);


### PR DESCRIPTION
## 📋 概要

TODOに親子関係を管理する機能を追加しました。この機能により、TODO同士の親子関係を動的に割り当てたり解除したりすることが可能になります。

## 🔨 変更内容

### 新機能の追加
#### 親子関係をアタッチ
- `POST` `/todos/{todoId}/attach-parent`エンドポイントを追加。
- 指定したTODOに対し、新しい親TODOを割り当てる処理を実装。
#### 親子関係をデタッチ
- `DELETE` `/todos/{todoId}/detach-parent`エンドポイントを追加。
- 指定したTODOの親TODOを解除し、自己参照のみに戻す処理を実装。
	
## 🧪 テスト
- [ ] **Unitテスト**:
    - attachおよびdetachエンドポイントのバリデーションロジックをカバーする単体テストを追加。
- [ ] **Featureテスト**:
    - 親子関係を動的に追加および削除できることを確認する結合テストを実装。
- [x] **手動テスト**:
    - APIエンドポイントが期待通りに動作することを確認。
	
## 🔗 関連するIssue

- Closes #1

## 🔭 影響範囲
- TODO管理機能全般。
- 閉包テーブルを利用した親子関係に関連する部分。
	
## 🧐 注意事項
- なし